### PR TITLE
putting constants in config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,7 @@ $RECYCLE.BIN/
 # Mac crap
 .DS_Store
 SharedLibrary/Proxies/ProxiesList.txt
+
+proxies.txt
+mongo.config
+

--- a/AppsExporter/App.config
+++ b/AppsExporter/App.config
@@ -1,6 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+	<configSections>
+		<section name="mongoSettings" type="System.Configuration.NameValueSectionHandler, System" />
+		<section name="languageStrings" type="System.Configuration.NameValueSectionHandler, System" />
+	</configSections>
+
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
+
+	<mongoSettings configSource="mongo.config" />
+	<languageStrings configSource="language.config" />
 </configuration>

--- a/AppsExporter/AppsExporter.csproj
+++ b/AppsExporter/AppsExporter.csproj
@@ -73,4 +73,9 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Target Name="AfterBuild">
+  	<Copy SourceFiles="../mongo.config" DestinationFolder="$(OutputPath)" ContinueOnError="false" />
+  	<Copy SourceFiles="../language.config" DestinationFolder="$(OutputPath)" ContinueOnError="false" />
+  	<Copy SourceFiles="../proxies.txt" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
+  </Target>
 </Project>

--- a/PlayStoreCrawler/App.config
+++ b/PlayStoreCrawler/App.config
@@ -1,10 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+	<configSections>
+		<section name="mongoSettings" type="System.Configuration.NameValueSectionHandler, System" />
+		<section name="languageStrings" type="System.Configuration.NameValueSectionHandler, System" />
+	</configSections>
+
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
-  <appSettings>
-    <add key="AWSAccessKey" value="AKIAI736OLL3GY3ZHSUA"/><!-- Amazon Credentials -->
-    <add key="AWSSecretKey" value="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"/><!-- Amazon Credentials -->
-  </appSettings>
+
+	<appSettings>
+		<add key="AWSAccessKey" value="AKIAI736OLL3GY3ZHSUA"/><!-- Amazon Credentials -->
+		<add key="AWSSecretKey" value="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"/><!-- Amazon Credentials -->
+	</appSettings>
+
+	<mongoSettings configSource="mongo.config" />
+	<languageStrings configSource="language.config" />
 </configuration>

--- a/PlayStoreCrawler/PlayStoreCrawler.csproj
+++ b/PlayStoreCrawler/PlayStoreCrawler.csproj
@@ -86,4 +86,9 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Target Name="AfterBuild">
+  	<Copy SourceFiles="../mongo.config" DestinationFolder="$(OutputPath)" ContinueOnError="false" />
+  	<Copy SourceFiles="../language.config" DestinationFolder="$(OutputPath)" ContinueOnError="false" />
+  	<Copy SourceFiles="../proxies.txt" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
+  </Target>
 </Project>

--- a/PlayStoreWorker/App.config
+++ b/PlayStoreWorker/App.config
@@ -1,6 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+	<configSections>
+		<section name="mongoSettings" type="System.Configuration.NameValueSectionHandler, System" />
+		<section name="languageStrings" type="System.Configuration.NameValueSectionHandler, System" />
+	</configSections>
+
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
+
+	<mongoSettings configSource="mongo.config" />
+	<languageStrings configSource="language.config" />
 </configuration>

--- a/PlayStoreWorker/PlayStoreWorker.csproj
+++ b/PlayStoreWorker/PlayStoreWorker.csproj
@@ -89,4 +89,9 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Target Name="AfterBuild">
+  	<Copy SourceFiles="../mongo.config" DestinationFolder="$(OutputPath)" ContinueOnError="false" />
+  	<Copy SourceFiles="../language.config" DestinationFolder="$(OutputPath)" ContinueOnError="false" />
+  	<Copy SourceFiles="../proxies.txt" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
+  </Target>
 </Project>

--- a/ReviewsParser/App.config
+++ b/ReviewsParser/App.config
@@ -1,6 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
+	<configSections>
+		<section name="mongoSettings" type="System.Configuration.NameValueSectionHandler, System" />
+		<section name="languageStrings" type="System.Configuration.NameValueSectionHandler, System" />
+	</configSections>
+
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
     </startup>
+
+	<mongoSettings configSource="mongo.config" />
+	<languageStrings configSource="language.config" />
 </configuration>

--- a/ReviewsParser/ReviewsWorker.csproj
+++ b/ReviewsParser/ReviewsWorker.csproj
@@ -84,4 +84,9 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Target Name="AfterBuild">
+  	<Copy SourceFiles="../mongo.config" DestinationFolder="$(OutputPath)" ContinueOnError="false" />
+  	<Copy SourceFiles="../language.config" DestinationFolder="$(OutputPath)" ContinueOnError="false" />
+  	<Copy SourceFiles="../proxies.txt" DestinationFolder="$(OutputPath)" ContinueOnError="true" />
+  </Target>
 </Project>

--- a/SharedLibrary/Consts.cs
+++ b/SharedLibrary/Consts.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Configuration;
+using System.Collections.Specialized;
 
 namespace SharedLibrary
 {
@@ -61,25 +63,23 @@ namespace SharedLibrary
         public static readonly string WHATS_NEW            = "//div[@class='recent-change']";
 
         // HTML Values
-        public static readonly string NO_RESULT_MESSAGE = "Nenhum resultado para sua pesquisa"; // TODO: CHANGE THIS TO YOUR OWN LANGUAGE. 
-                                                                                                // THIS CONSTANT IS USED TO CHECK FOR "NO MORE APPS" WHEN YOU PAGINATE/SCROLL THROUGH
-                                                                                                // THE SEARCH RESULTS. THE PHRASE MEANS "NO RESULT FOR YOUR SEARCH"
+		public static string NO_RESULT_MESSAGE 		{ get { var lang = ConfigurationManager.GetSection("languageStrings") as NameValueCollection; return lang[lang["chosen-language"]]; } }
         
         // Retry Values
         public static readonly int MAX_REQUEST_ERRORS   = 100;
         public static readonly int MAX_QUEUE_TRIES      = 5;
         
         // MongoDB - Remote Server
-        public static readonly string MONGO_SERVER           = "mobiledata.bigdatacorp.com.br"; 
-        public static readonly string MONGO_PORT             = "21766";
-        public static readonly string MONGO_USER             = "GitHubCrawlerUser";
-        public static readonly string MONGO_PASS             = "g22LrJvULU5B";
-        public static readonly string MONGO_DATABASE         = "MobileAppsData";
-        public static readonly string MONGO_COLLECTION       = "PlayStore_2015_09";
-        public static readonly string REVIEWS_COLLECTION     = "ProcessedReviews";
-        public static readonly string QUEUED_APPS_COLLECTION = "PlayStore_QueuedApps_2015_09";
-        public static readonly string REVIEWERS_COLLECTION   = "ReviewersData";
-        public static readonly string MONGO_AUTH_DB          = "MobileAppsData";
+		public static string MONGO_SERVER           { get { var mongo = ConfigurationManager.GetSection("mongoSettings") as NameValueCollection; return mongo["server"]; } }
+		public static string MONGO_PORT             { get { var mongo = ConfigurationManager.GetSection("mongoSettings") as NameValueCollection; return mongo["port"]; } }
+		public static string MONGO_USER             { get { var mongo = ConfigurationManager.GetSection("mongoSettings") as NameValueCollection; return mongo["user"]; } }
+		public static string MONGO_PASS             { get { var mongo = ConfigurationManager.GetSection("mongoSettings") as NameValueCollection; return mongo["password"]; } }
+		public static string MONGO_DATABASE         { get { var mongo = ConfigurationManager.GetSection("mongoSettings") as NameValueCollection; return mongo["database"]; } }
+		public static string MONGO_COLLECTION       { get { var mongo = ConfigurationManager.GetSection("mongoSettings") as NameValueCollection; return mongo["apps-collection"]; } }
+		public static string REVIEWS_COLLECTION     { get { var mongo = ConfigurationManager.GetSection("mongoSettings") as NameValueCollection; return mongo["reviews-collection"]; } }
+		public static string QUEUED_APPS_COLLECTION { get { var mongo = ConfigurationManager.GetSection("mongoSettings") as NameValueCollection; return mongo["queued-apps-collection"]; } }
+		public static string REVIEWERS_COLLECTION   { get { var mongo = ConfigurationManager.GetSection("mongoSettings") as NameValueCollection; return mongo["reviewers-collection"]; } }
+		public static string MONGO_AUTH_DB          { get { var mongo = ConfigurationManager.GetSection("mongoSettings") as NameValueCollection; return mongo["auth-db"]; } }
         public static readonly int    MONGO_TIMEOUT          = 120000;
 
         // Date Time Format

--- a/language.config
+++ b/language.config
@@ -1,0 +1,5 @@
+<languageStrings>
+	<add key="chosen-language" value="pt-br" />
+	<add key="en" value="No results for your search" />	
+	<add key="pt-br" value="Nenhum resultado para sua pesquisa" />
+</languageStrings>

--- a/mongo.sample.config
+++ b/mongo.sample.config
@@ -1,0 +1,12 @@
+<mongoSettings>
+	<add key="server" value="mobiledata.bigdatacorp.com.br" />
+	<add key="port" value="21766" />
+	<add key="user" value="GitHubCrawlerUser" />
+	<add key="password" value="g22LrJvULU5B" />
+	<add key="database" value="MobileAppsData" />
+	<add key="apps-collection" value="PlayStore_2015_09" />
+	<add key="reviews-collection" value="ProcessedReviews" />
+	<add key="queued-apps-collection" value="PlayStore_QueuedApps_2015_09" />
+	<add key="reviewers-collection" value="ReviewersData" />
+	<add key="auth-db" value="MobileAppsData" />
+</mongoSettings>


### PR DESCRIPTION
basically:

* all of Consts.cs, where relevant, is in a config file - this means there is no need to recompile every time something needs to be changed. This is great for a multi-system deployment.
* there is a language.config file where any language can be added, so it is no longer needed to change the config file to match.
* the projects that use the config files (AppsExporter, PlayStoreCrawler, PlayStoreWorker, ReviewsParser) all copy: `proxies.txt`, `mongo.config`, `language.config` to their deploy directory.

You'll notice I did _not_ include a `mongo.config` (it is also `.gitignore`'d), but instead a `mongo.sample.config` (all I did was copy your credentials out of Consts and into a config). Please encourage people to look at the config files before running anything.

You'll also notice I added `proxies.txt` - I know you have something in the proxy project but since most projects seem to take in a file as an argument, I wanted a place where this file could just be put and copied more easily.

I also recommend getting rid of your AWS credentials. I know you like being open, but it could end really badly if you continue to leave them there. I left them in because it's not in the scope of my PR to change it and ultimately it's not up to me.