### PR TITLE
ignore empty lines

### DIFF
--- a/SharedLibrary/Proxies/ProxiesLoader.cs
+++ b/SharedLibrary/Proxies/ProxiesLoader.cs
@@ -24,6 +24,10 @@ namespace SharedLibrary.Proxies
             // Adding proxies from the file
             foreach (string proxyData in proxies)
             {
+
+				if (String.IsNullOrEmpty (proxyData))
+					continue;
+
                 // Splitting String for it's data
                 string[] proxyInfo = proxyData.Split (':');
 


### PR DESCRIPTION
small crash happens if there's an empty line in your proxy file - those should just be ignored.